### PR TITLE
Close response stream

### DIFF
--- a/gen/_template/response_encode.tmpl
+++ b/gen/_template/response_encode.tmpl
@@ -140,6 +140,7 @@ func encode{{ $op.Name }}Response(response {{ $op.Responses.GoType }}, w http.Re
 		{{- end }}
 		{{ template "respond/return" $}}
 	{{- else if $type.IsStream }}
+		defer {{ $var }}.Close()
 		{{- if $type.IsBase64Stream }}
 		writer := base64.NewEncoder(base64.StdEncoding, w)
 		defer writer.Close()


### PR DESCRIPTION
When generating an endpoint that returns a stream as a response, the stream should be closed after being written to the response buffer (or on error).